### PR TITLE
Updated the unknown items to TP7 and TP8 Data in the Packet Layout. Thes...

### DIFF
--- a/doc/emotiv_protocol.asciidoc
+++ b/doc/emotiv_protocol.asciidoc
@@ -127,23 +127,23 @@ An Overview of the 256-bit Packet Layout:
 | 0:7   | Counter/Battery
 | 8:21  | F3 Data
 | 22:35 | FC5 Data
-| 36:49 | AF3 Data
+| 36:49 | AF7 Data
 | 50:63 | F7 Data
 | 64:77 | T7 Data
 | 78:91 | P7 Data
 | 92:105 | O1 Data
 | 107:120 | Connection Quality (Rotating)
-| 121:133 | Unknown
+| 121:133 | TP7 Data
 | 134:147 | O2 Data
 | 148:161 | P8 Data
 | 162:175 | T8 Data
 | 176:189 | F8 Data
-| 190:203 | AF4 Data
+| 190:203 | AF8 Data
 | 204:217 | FC6 Data
 | 218:231 | F4 Data
 | 233:239 | Gyro X
 | 240:247 | Gyro Y
-| 248:255 | Unknown
+| 248:255 | TP8 Data
 |=============================
 
 === Counter and Battery


### PR DESCRIPTION
...e were determined by looking at the extra sensors available and cross-referencing them to the 10-20 International Electrode Placement diagram. Those locations were then cross-referenced by Emotiv Headset Setup guide images. Future tests could confirm this via selective channel data gathering.

In addition switched the AF3 Data -> AF7 Data and AF4 Data -> AF8 in the packet layout. The electrode placement did not seem to line up on scalp for most users to correlate with areas AF3/AF4. In addition when referencing the Emotiv Headset Setup Guide with the 10-20 International Electrode Placement Diagram that also confirmed that change. 

-Emily O'Leary 07.19.2012
