### PR TITLE
Blocking device read() call destroys gevent

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Python library
     if __name__ == "__main__":
       headset = emotiv.Emotiv()    
       gevent.spawn(headset.setup)
-      gevent.sleep(1)
+      gevent.sleep(0)
       try:
         while True:
           packet = headset.dequeue()

--- a/python/mouse_control.py
+++ b/python/mouse_control.py
@@ -52,21 +52,22 @@ def main(debug=False):
         width = screen.width
         height = screen.height
 
-        curX, curY = width / 2, height / 2
-        while True:
-            updated = False
-            packet = emotiv.dequeue()
-            if abs(packet.gyroX) > 1:
-                curX -= packet.gyroX
-                updated = True
-            if abs(packet.gyroY) > 1:
-                curY += packet.gyroY
-                updated = True
-            curX = max(0, min(curX, width))
-            curY = max(0, min(curY, height))
-            if updated:
-                screen.move_mouse(curX, curY)
-            gevent.sleep(0)
+    curX, curY = width / 2, height / 2
+    while True:
+        updated = False
+        packet = emotiv.dequeue()
+        print "%s %s" % (packet.gyroX, packet.gyroY)
+        if abs(packet.gyroX) > 1:
+            curX -= packet.gyroX
+            updated = True
+        if abs(packet.gyroY) > 1:
+            curY += packet.gyroY
+            updated = True
+        curX = max(0, min(curX, width))
+        curY = max(0, min(curY, height))
+        if updated:
+            screen.move_mouse(curX, curY)
+        gevent.sleep(0)
 
 
 emotiv = None


### PR DESCRIPTION
Hey,

it's cool that you introduced gevent into the Python code, I think that makes many things much easier to write.

However, there is one issue with that: The `hidraw.read(32)` call is blocking and therefore stops all gevent threads.

It also introduced a bug that an *initial* `gevent.sleep(1)`, as was written in the README example code so far, would delay all EEG data by one second even though this sleep was not in the main loop.

This change fixes all of this by doing this call from a separate real thread, simply forwarding all data to the existing `gevent.Queue` via threading `Queues`.

It would be even better to instead do an event driven `read()` (using `select/epoll/kqueue` techniques, so probably even `gevent.select` in our case), but as far as I know that is not cross-platform; the overhead introduced by the poll I have implemented is quite low and can be traded off for latency (the current default value is 1 ms).

**I could not test the this with windows and OS-level decryption**, so it would be great if somebody could have a short look if that still works as expected.

(By the way, you are doing a great job here. Emokit is super useful.)