### PR TITLE
fix gyroY in python according to nh2

### DIFF
--- a/python/emokit/emotiv.py
+++ b/python/emokit/emotiv.py
@@ -164,7 +164,7 @@ class EmotivPacket(object):
 
         # the RESERVED byte stores the least significant 4 bits for gyroX and gyroY
         self.gyroX = ((ord(data[29]) << 4) | (ord(data[31]) >> 4))
-        self.gyroY = ((ord(data[30]) << 4) | (ord(data[31]) & 0xFF))
+        self.gyroY = ((ord(data[30]) << 4) | (ord(data[31]) & 0x0F))
         sensors['X']['value'] = self.gyroX
         sensors['Y']['value'] = self.gyroY
 


### PR DESCRIPTION
The gyro parser was still wrong.

https://github.com/openyou/emokit/commit/b023a3c1
