### PR TITLE
Add suport for Emotiv EEG

### DIFF
--- a/python/emokit/emotiv.py
+++ b/python/emokit/emotiv.py
@@ -384,7 +384,7 @@ class Emotiv(object):
                 with open(input[0] + "/manufacturer", 'r') as f:
                     manufacturer = f.readline()
                     f.close()
-                if "Emotiv Systems Inc." in manufacturer:
+                if ("Emotiv Systems Inc." in manufacturer) or ("Emotiv Systems Pty Ltd" in manufacturer) :
                     with open(input[0] + "/serial", 'r') as f:
                         serial = f.readline().strip()
                         f.close()


### PR DESCRIPTION
When detecting the device corresponding to the Emotiv headset, only "Emotiv System Inc." is searched as manufacturer, which I suppose is related to the Emotiv EPOC. Nevertheless, my Emotiv EEG headset shows "Emotiv Systems Pty Ltd" as manufacturer, so you should also look for this.
