### PR TITLE
added verbose, fixed hidraw bug on linux, store quality as float

### DIFF
--- a/python/emokit/emotiv.py
+++ b/python/emokit/emotiv.py
@@ -227,17 +227,20 @@ def get_linux_setup(device=-1, verbose=False):
             i += 1
         raw_inputs.append([path, filename])
     for rinput in raw_inputs:
-        with open(rinput[0] + "/manufacturer", 'r') as f:
-            manufacturer = f.readline()
-            f.close()
-        if eeg_manufacturer in manufacturer:
-            with open(rinput[0] + "/serial", 'r') as f:
-                serial = f.readline().strip()
+        try:
+            with open(rinput[0] + "/manufacturer", 'r') as f:
+                manufacturer = f.readline()
                 f.close()
-            if verbose:
-                print "Detected " + "Serial: " + serial + " Device: " + rinput[1]
-            hidraws.append(rinput[1])
-            serials.append(serial)
+            if eeg_manufacturer in manufacturer:
+                with open(rinput[0] + "/serial", 'r') as f:
+                    serial = f.readline().strip()
+                    f.close()
+                if verbose:
+                    print "Detected " + "Serial: " + serial + " Device: " + rinput[1]
+                hidraws.append(rinput[1])
+                serials.append(serial)
+        except:
+            pass
     if not len(hidraws):
         raise IOError("Could not find a USB device with manufacturer: %s" % eeg_manufacturer)
     if verbose:


### PR DESCRIPTION
Added a verbose option to control print messages.
Resolved the following bugs:
Emotiv Epoc (2013) would create 2 USB devices on linux. The original version of the code would simply use hidrawx and hidrawx+1 where x is the initial emotiv device detected. This does not always work. The updated version keeps track of both emotiv hidraw IDs and uses the second one by default (usually the one that actually has data).
The original version of the code uses integer division to store quality, the updated version uses float division producing more informative quality values.